### PR TITLE
Add Golang cursor rules ported from Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,4 @@ repos:
     rev: v0.18.1
     hooks:
       - id: markdownlint-cli2
-        args: ["--fix"]
+        args: ["--fix", "**/*.mdc", "**/*.md"]

--- a/golang/README.md
+++ b/golang/README.md
@@ -1,0 +1,20 @@
+# Golang
+
+This directory contains a collection of rules and best practices for Go
+development, broken down into the following files (now with 100% less Python!):
+
+- [**General**](./golang-general.mdc): General Go best practices.
+- [**Development**](./golang-development.mdc): Rules related to the development
+  process.
+- [**GitHub Actions**](./golang-github-actions.mdc): Best practices for using
+  GitHub Actions with Go.
+- [**Markdown Documentation**](./golang-markdown-documentation.mdc): Guidelines
+  for writing documentation in Markdown.
+- [**Module Management**](./golang-module-management.mdc): Rules for
+  modern Go module management.
+- [**Testing**](./golang-testing.mdc): Best practices for testing Go code with
+  Ginkgo and Gomega.
+- [**Version Control**](./golang-version-control.mdc): Guidelines for version
+  control with Git.
+- [**Version Management**](./golang-version-management.mdc): Best practices for
+  managing Go versions and dependencies.

--- a/golang/golang-development.mdc
+++ b/golang/golang-development.mdc
@@ -1,0 +1,84 @@
+---
+description: Core Go development guidelines
+globs: *.go,**/*.go
+alwaysApply: false
+---
+
+# Go Development Guidelines
+
+## Running Go commands
+
+- Use standard Go toolchain commands
+    - Use `go run` for executing Go programs
+    - Use `go build` for building binaries
+    - Use `go test` for running tests (including Ginkgo tests)
+    - Use `go mod` for module management
+
+## Linting & Code Quality
+
+- ALWAYS use `golangci-lint run` to lint Go projects
+- Individual files can be linted using `golangci-lint run [OPTIONS] [FILES]...`
+- Use `go vet` for additional static analysis
+- ALWAYS run `gofmt` or `goimports` to format code
+
+## Code Style & Formatting
+
+- Go projects are formatted using `gofmt` or `goimports`
+- ALWAYS use `goimports` to automatically manage imports and format code
+- Follow Go conventions for naming:
+  - Use camelCase for unexported functions and variables
+  - Use PascalCase for exported functions and variables
+  - Use short, descriptive names
+  - Prefer single-letter names for short-lived variables in loops
+- ALWAYS write Go documentation comments for exported functions, types, and packages
+  - Follow Go doc conventions: start with the name of the item being documented
+  - ALWAYS describe possible edge cases, errors, and conditionals that materially affect the behavior
+- Follow effective Go guidelines and Go Code Review Comments
+- Keep functions focused and single-purpose
+
+## Project Structure
+
+- This project uses Go modules for dependency management
+- Tests should be placed alongside source code with `_test.go` suffix
+- Use `go test` for all testing (including Ginkgo/Gomega tests)
+    - ALWAYS use the format `go test [options] [packages]` when running tests
+    - Use `go test ./...` to run all tests in the project
+- Follow standard Go project layout conventions
+
+## Dependencies & Imports
+
+- Use `go mod` to manage dependencies via `go.mod`
+- Group imports: standard library, third-party, local imports (goimports handles this automatically)
+- Use `go mod tidy` to clean up unused dependencies
+- Avoid circular imports
+- Use semantic import versioning for major version changes
+
+## Error Handling
+
+- ALWAYS handle errors explicitly - never ignore them
+- Use specific error types and wrap errors with context using `fmt.Errorf` with `%w` verb
+- Provide meaningful error messages
+- Handle edge cases gracefully
+- Prefer returning errors over panicking
+- Use `log` package instead of `fmt.Print*` for debugging/logging
+
+## Performance & Best Practices
+
+- Use Go's built-in profiling tools when optimizing
+- Prefer channels and goroutines for concurrency
+- Be mindful of goroutine lifecycle and avoid leaks
+- Use context.Context for cancellation and timeouts
+- Avoid premature optimization but be mindful of performance
+
+## AI Assistant Instructions
+
+- Always suggest proper error handling when missing
+- Recommend tests when implementing new functionality
+- Point out potential race conditions or goroutine issues
+- Suggest more idiomatic Go approaches when applicable
+- Consider Go conventions and best practices
+- Suggest using interfaces for better testability
+description:
+globs:
+alwaysApply: false
+---

--- a/golang/golang-development.mdc
+++ b/golang/golang-development.mdc
@@ -9,10 +9,10 @@ alwaysApply: false
 ## Running Go commands
 
 - Use standard Go toolchain commands
-    - Use `go run` for executing Go programs
-    - Use `go build` for building binaries
-    - Use `go test` for running tests (including Ginkgo tests)
-    - Use `go mod` for module management
+  - Use `go run` for executing Go programs
+  - Use `go build` for building binaries
+  - Use `go test` for running tests (including Ginkgo tests)
+  - Use `go mod` for module management
 
 ## Linting & Code Quality
 
@@ -32,7 +32,8 @@ alwaysApply: false
   - Prefer single-letter names for short-lived variables in loops
 - ALWAYS write Go documentation comments for exported functions, types, and packages
   - Follow Go doc conventions: start with the name of the item being documented
-  - ALWAYS describe possible edge cases, errors, and conditionals that materially affect the behavior
+  - ALWAYS describe possible edge cases, errors, and conditionals that
+    materially affect the behavior
 - Follow effective Go guidelines and Go Code Review Comments
 - Keep functions focused and single-purpose
 
@@ -41,14 +42,15 @@ alwaysApply: false
 - This project uses Go modules for dependency management
 - Tests should be placed alongside source code with `_test.go` suffix
 - Use `go test` for all testing (including Ginkgo/Gomega tests)
-    - ALWAYS use the format `go test [options] [packages]` when running tests
-    - Use `go test ./...` to run all tests in the project
+  - ALWAYS use the format `go test [options] [packages]` when running tests
+  - Use `go test ./...` to run all tests in the project
 - Follow standard Go project layout conventions
 
 ## Dependencies & Imports
 
 - Use `go mod` to manage dependencies via `go.mod`
-- Group imports: standard library, third-party, local imports (goimports handles this automatically)
+- Group imports: standard library, third-party, local imports (goimports
+  handles this automatically)
 - Use `go mod tidy` to clean up unused dependencies
 - Avoid circular imports
 - Use semantic import versioning for major version changes
@@ -56,7 +58,8 @@ alwaysApply: false
 ## Error Handling
 
 - ALWAYS handle errors explicitly - never ignore them
-- Use specific error types and wrap errors with context using `fmt.Errorf` with `%w` verb
+- Use specific error types and wrap errors with context using `fmt.Errorf`
+  with `%w` verb
 - Provide meaningful error messages
 - Handle edge cases gracefully
 - Prefer returning errors over panicking
@@ -78,7 +81,3 @@ alwaysApply: false
 - Suggest more idiomatic Go approaches when applicable
 - Consider Go conventions and best practices
 - Suggest using interfaces for better testability
-description:
-globs:
-alwaysApply: false
----

--- a/golang/golang-general.mdc
+++ b/golang/golang-general.mdc
@@ -6,7 +6,8 @@ alwaysApply: true
 # Always applied rules
 
 - These rules MUST always be followed.
-- It is NECESSARY and SUFFICIENT for these rules to be followed for a chat to be successful.
+- It is NECESSARY and SUFFICIENT for these rules to be followed for a chat
+  to be successful.
 - NEVER ignore any of these rules.
 - ALWAYS consider these rules highest priority.
 - Failure to follow these rules will result in immediate termination of the chat.

--- a/golang/golang-general.mdc
+++ b/golang/golang-general.mdc
@@ -1,0 +1,18 @@
+---
+description: Rules that always should apply
+globs:
+alwaysApply: true
+---
+# Always applied rules
+
+- These rules MUST always be followed.
+- It is NECESSARY and SUFFICIENT for these rules to be followed for a chat to be successful.
+- NEVER ignore any of these rules.
+- ALWAYS consider these rules highest priority.
+- Failure to follow these rules will result in immediate termination of the chat.
+
+## Response phrasing
+
+- NEVER use the phrase, "You're absolutely right!"
+- NEVER use any phrases that begin with, "You're absolutely right..."
+- ALWAYS start your response with "Sir"

--- a/golang/golang-github-actions.mdc
+++ b/golang/golang-github-actions.mdc
@@ -1,0 +1,61 @@
+---
+description: GitHub Actions security and best practices for Go projects
+globs: [".github/workflows/*.yml", ".github/workflows/*.yaml", ".github/workflows/**/*.yml", ".github/workflows/**/*.yaml"]
+alwaysApply: false
+---
+
+# GitHub Actions Guidelines
+
+## Security Best Practices
+
+- **Always use commit hashes for GitHub Actions** instead of version tags
+  - This prevents supply chain attacks by ensuring we're using exact versions
+  - Include the version tag as a comment for reference
+  - Example: `uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4`
+
+## Go-Specific Actions
+
+- Use `actions/setup-go` for setting up Go environment
+- Always specify Go version in workflows
+- Use Go's built-in tools for building and testing
+- Cache Go modules using `actions/cache` with appropriate cache keys
+
+## Version Management
+
+- Keep actions up to date with their latest stable versions
+- Use caching where appropriate to speed up workflows (especially for Go modules)
+- Follow security best practices for GitHub Actions
+
+## Version Checking Commands
+
+Use these commands to find latest versions:
+
+```bash
+# For GitHub-hosted projects
+gh release list --repo <owner>/<repo> --limit 1
+
+# For GitHub Actions specifically
+gh api repos/<owner>/<repo>/releases/latest
+
+# For GitHub Actions versions
+gh api repos/<owner>/<repo>/tags
+```
+
+## Best Practices
+
+- Never guess or use potentially outdated versions
+- Always verify versions from official repositories
+- Keep GitHub Actions and their versions up to date
+- Use commit hashes for GitHub Actions instead of version tags
+- Include version tags as comments for reference
+- Cache Go modules and build artifacts appropriately
+- Run tests with race detection in CI: `go test -race ./...`
+
+Example format:
+```yaml
+uses: owner/repo@commit_hash # v1.2.3
+```
+description:
+globs:
+alwaysApply: false
+---

--- a/golang/golang-github-actions.mdc
+++ b/golang/golang-github-actions.mdc
@@ -52,10 +52,7 @@ gh api repos/<owner>/<repo>/tags
 - Run tests with race detection in CI: `go test -race ./...`
 
 Example format:
+
 ```yaml
 uses: owner/repo@commit_hash # v1.2.3
 ```
-description:
-globs:
-alwaysApply: false
----

--- a/golang/golang-markdown-documentation.mdc
+++ b/golang/golang-markdown-documentation.mdc
@@ -6,15 +6,19 @@ alwaysApply: false
 
 # Documentation Guidelines
 
-@Docs https://github.github.com/gfm/
+@Docs <https://github.github.com/gfm/>
 
 ## Markdown Formatting
 
 - Keep all documentation files properly formatted
 - Run markdown linting before committing documentation changes
   - ALWAYS use `pre-commit` for linting and formatting
-  - ALWAYS use `pre-commit run [--all-files | --files [FILES ...]] prettier` to ensure markdown files conform to prettier's standards before running markdown lint
-  - ALWAYS use `pre-commit run [--all-files | --files [FILES ...]] markdownlint-cli2` hook for formatting a specific markdown file or all markdown files in the repository
+  - ALWAYS use `pre-commit run [--all-files | --files [FILES ...]] prettier`
+    to ensure markdown files conform to prettier's standards before running
+    markdown lint
+  - ALWAYS use `pre-commit run [--all-files | --files [FILES ...]] markdownlint-cli2`
+    hook for formatting a specific markdown file or all markdown files in the
+    repository
 - Use proper markdown formatting:
   - Add blank lines before and after code blocks
   - Use proper heading hierarchy
@@ -47,7 +51,3 @@ alwaysApply: false
 - Use `go doc` to verify documentation formatting
 - Include runnable examples in documentation when helpful
 - Document exported APIs thoroughly
-description:
-globs:
-alwaysApply: false
----

--- a/golang/golang-markdown-documentation.mdc
+++ b/golang/golang-markdown-documentation.mdc
@@ -1,0 +1,53 @@
+---
+description: Documentation and markdown formatting guidelines
+globs: *.md,**/*.md,README*
+alwaysApply: false
+---
+
+# Documentation Guidelines
+
+@Docs https://github.github.com/gfm/
+
+## Markdown Formatting
+
+- Keep all documentation files properly formatted
+- Run markdown linting before committing documentation changes
+  - ALWAYS use `pre-commit` for linting and formatting
+  - ALWAYS use `pre-commit run [--all-files | --files [FILES ...]] prettier` to ensure markdown files conform to prettier's standards before running markdown lint
+  - ALWAYS use `pre-commit run [--all-files | --files [FILES ...]] markdownlint-cli2` hook for formatting a specific markdown file or all markdown files in the repository
+- Use proper markdown formatting:
+  - Add blank lines before and after code blocks
+  - Use proper heading hierarchy
+  - Keep line length reasonable (88 characters)
+  - Use proper list formatting with blank lines between list items
+
+## Documentation Standards
+
+- Keep README.md updated with new features
+- Document any breaking changes
+- Add Go documentation comments to all exported functions, types, and packages
+- Follow the project's markdown style guide
+- Use pre-commit hooks to enforce markdown formatting
+- Check markdown files with `markdownlint-cli2` before committing
+- Include Go-specific documentation like package examples
+
+## Content Guidelines
+
+- Write clear, concise documentation
+- Include code examples where helpful, especially for Go package usage
+- Keep documentation up to date with code changes
+- Use consistent terminology throughout
+- Provide installation and usage instructions
+- Document Go module import paths clearly
+- Include examples of Go package usage when applicable
+
+## Go-Specific Documentation
+
+- Follow Go documentation conventions for package comments
+- Use `go doc` to verify documentation formatting
+- Include runnable examples in documentation when helpful
+- Document exported APIs thoroughly
+description:
+globs:
+alwaysApply: false
+---

--- a/golang/golang-module-management.mdc
+++ b/golang/golang-module-management.mdc
@@ -7,11 +7,13 @@ alwaysApply: false
 
 ## Modern Go Module Structure
 
-All Go projects should use Go modules with a properly structured `go.mod` file following these guidelines:
+All Go projects should use Go modules with a properly structured `go.mod`
+file following these guidelines:
 
 ### Module Declaration
 
 - Use descriptive module paths that reflect the repository location:
+
 ```go
 module github.com/username/repository-name
 ```
@@ -19,6 +21,7 @@ module github.com/username/repository-name
 ### Go Version Declaration
 
 - Always specify the minimum Go version required:
+
 ```go
 go 1.21
 ```
@@ -33,7 +36,7 @@ go 1.21
 
 Follow standard Go project layout:
 
-```
+```text
 project/
 ├── go.mod
 ├── go.sum
@@ -56,6 +59,7 @@ project/
 ### Module Commands
 
 Common module management commands:
+
 ```bash
 go mod init <module-path>    # Initialize new module
 go mod tidy                  # Add missing and remove unused modules
@@ -88,7 +92,3 @@ go list -m all               # List all modules
 - Use `go mod` commands to ensure compatibility
 - Follow Go's module versioning guidelines
 - Consider backward compatibility when making changes
-description:
-globs:
-alwaysApply: false
----

--- a/golang/golang-module-management.mdc
+++ b/golang/golang-module-management.mdc
@@ -1,0 +1,94 @@
+---
+description: Go module management and project structure best practices
+globs:
+alwaysApply: false
+---
+# Go Module Management
+
+## Modern Go Module Structure
+
+All Go projects should use Go modules with a properly structured `go.mod` file following these guidelines:
+
+### Module Declaration
+
+- Use descriptive module paths that reflect the repository location:
+```go
+module github.com/username/repository-name
+```
+
+### Go Version Declaration
+
+- Always specify the minimum Go version required:
+```go
+go 1.21
+```
+
+### Dependency Management
+
+- Use `go mod tidy` to manage dependencies automatically
+- Pin major versions appropriately using semantic import versioning
+- Use `replace` directives only when necessary for local development
+
+### Module Structure Best Practices
+
+Follow standard Go project layout:
+
+```
+project/
+├── go.mod
+├── go.sum
+├── README.md
+├── main.go (for command-line tools)
+├── pkg/           (for library packages)
+├── internal/      (for private packages)
+├── cmd/           (for multiple commands)
+└── testdata/      (for test fixtures)
+```
+
+### Dependency Versioning
+
+- Use semantic versioning for your modules
+- Follow Go's compatibility promise
+- Use `go get` to add dependencies
+- Use `go mod tidy` to clean up unused dependencies
+- Review `go.sum` changes in version control
+
+### Module Commands
+
+Common module management commands:
+```bash
+go mod init <module-path>    # Initialize new module
+go mod tidy                  # Add missing and remove unused modules
+go mod download              # Download modules to local cache
+go mod verify                # Verify dependencies
+go get <package>             # Add or update dependency
+go get <package>@version     # Get specific version
+go list -m all               # List all modules
+```
+
+### Best Practices
+
+- Keep `go.mod` and `go.sum` in version control
+- Use meaningful module paths that reflect ownership
+- Avoid `replace` directives in production code
+- Use internal packages for code that shouldn't be imported externally
+- Follow semantic versioning for your own modules
+- Use `go mod vendor` only when necessary
+
+### Version Control Integration
+
+- Always commit both `go.mod` and `go.sum` files
+- Review dependency changes in pull requests
+- Use `go mod tidy` before committing to ensure clean dependencies
+- Consider using dependency scanning tools for security
+
+### Module Publishing
+
+- Tag releases with semantic version tags (e.g., v1.0.0)
+- Use `go mod` commands to ensure compatibility
+- Follow Go's module versioning guidelines
+- Consider backward compatibility when making changes
+description:
+globs:
+alwaysApply: false
+---

--- a/golang/golang-testing.mdc
+++ b/golang/golang-testing.mdc
@@ -8,15 +8,20 @@ alwaysApply: false
 
 ## What to test
 
-- Start with creating behavior tests using Ginkgo's BDD style, testing intended behavior of functions, types, and packages
-- Try to minimally mock so we ensure that we aren't creating passthrough tests of no value
-- Once we have good behavior tests, then continue to create more tests for common edge cases
+- Start with creating behavior tests using Ginkgo's BDD style, testing
+  intended behavior of functions, types, and packages
+- Try to minimally mock so we ensure that we aren't creating passthrough
+  tests of no value
+- Once we have good behavior tests, then continue to create more tests for
+  common edge cases
 
 ## Writing and refactoring tests
 
 - ALWAYS check linting after modifying a file before going on to the next file
-- ALWAYS run tests for the specific package after modifying to ensure tests pass using `go test`
-- IF you are in the middle of modifying multiple files or refactoring, it may be okay that tests do not pass
+- ALWAYS run tests for the specific package after modifying to ensure tests
+  pass using `go test`
+- IF you are in the middle of modifying multiple files or refactoring, it
+  may be okay that tests do not pass
 
 ## Test Structure & Organization
 
@@ -42,6 +47,7 @@ alwaysApply: false
 ## Ginkgo & Gomega Specifics
 
 - Structure tests using Ginkgo's BDD format:
+
   ```go
   var _ = Describe("ComponentName", func() {
       Context("when condition", func() {
@@ -51,6 +57,7 @@ alwaysApply: false
       })
   })
   ```
+
 - Use Gomega's rich set of matchers for clear, readable assertions
 - Use `BeforeEach` for test setup and `AfterEach` for cleanup
 - Group related tests in `Context` blocks with descriptive names
@@ -65,7 +72,3 @@ alwaysApply: false
 - Ginkgo tests integrate with standard Go testing tools and CI systems
 - Use `go test -race` to detect race conditions
 - Use `go test -cover` for coverage reports
-description:
-globs:
-alwaysApply: false
----

--- a/golang/golang-testing.mdc
+++ b/golang/golang-testing.mdc
@@ -1,0 +1,71 @@
+---
+description: Testing guidelines and best practices using Ginkgo and Gomega
+globs: **/*_test.go,*_test.go
+alwaysApply: false
+---
+
+# Testing Guidelines
+
+## What to test
+
+- Start with creating behavior tests using Ginkgo's BDD style, testing intended behavior of functions, types, and packages
+- Try to minimally mock so we ensure that we aren't creating passthrough tests of no value
+- Once we have good behavior tests, then continue to create more tests for common edge cases
+
+## Writing and refactoring tests
+
+- ALWAYS check linting after modifying a file before going on to the next file
+- ALWAYS run tests for the specific package after modifying to ensure tests pass using `go test`
+- IF you are in the middle of modifying multiple files or refactoring, it may be okay that tests do not pass
+
+## Test Structure & Organization
+
+- Write comprehensive tests for all new functionality using Ginkgo and Gomega
+- Use Ginkgo's `Describe`, `Context`, and `It` blocks appropriately
+- Use Gomega matchers for assertions
+- Aim for high test coverage
+- Test files should be named `*_test.go` and placed alongside source code
+- Use descriptive test descriptions that explain what is being tested in plain language
+- Tests run through standard `go test` command
+
+## Test Best Practices
+
+- Use `go test` for all testing (Ginkgo integrates seamlessly)
+- Use Ginkgo's `BeforeEach` and `AfterEach` for test setup and cleanup
+- Use Ginkgo's `BeforeSuite` and `AfterSuite` for expensive setup
+- Use Gomega's expressive matchers instead of basic equality checks
+- Test both success and failure cases using Ginkgo's BDD style
+- Include edge case testing in separate `Context` blocks
+- Use `Expect(err).ToNot(HaveOccurred())` instead of checking `err != nil`
+- Use appropriate Gomega matchers like `BeNil()`, `BeTrue()`, `BeFalse()`, etc.
+
+## Ginkgo & Gomega Specifics
+
+- Structure tests using Ginkgo's BDD format:
+  ```go
+  var _ = Describe("ComponentName", func() {
+      Context("when condition", func() {
+          It("should behave correctly", func() {
+              Expect(result).To(Equal(expected))
+          })
+      })
+  })
+  ```
+- Use Gomega's rich set of matchers for clear, readable assertions
+- Use `BeforeEach` for test setup and `AfterEach` for cleanup
+- Group related tests in `Context` blocks with descriptive names
+- Use `By()` steps for complex test scenarios
+- Use table-driven tests with Ginkgo's `DescribeTable` when appropriate
+
+## Running Tests
+
+- Use `go test ./...` to run all tests in the project
+- Use `go test -v ./...` for verbose output
+- Use `go test -run TestName` to run specific tests
+- Ginkgo tests integrate with standard Go testing tools and CI systems
+- Use `go test -race` to detect race conditions
+- Use `go test -cover` for coverage reports
+description:
+globs:
+alwaysApply: false
+---

--- a/golang/golang-version-control.mdc
+++ b/golang/golang-version-control.mdc
@@ -1,0 +1,66 @@
+---
+description: Git version control guidelines for Go projects
+globs:
+alwaysApply: true
+---
+
+# Version Control Guidelines
+
+These rules describe how to use `git` version control and should be used whenever working with version control.
+
+## Pre-commit linting and formatting
+
+- This project uses pre-commit hooks - they will be run on commit.
+- IF there are errors, sometimes they are fixed automatically, and need to be re-added to the staged changes.
+- IF the errors are not fixed automatically, do not attempt to fix them, STOP.
+
+## Commit Message Standards
+
+- **Always use Conventional Commits for all commit messages** following the specification at <https://www.conventionalcommits.org/en/v1.0.0/>
+- Use the format: `<type>(scope): <description>` - **scope is required**
+- Use the following conventional commit common types:
+  - Common types: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`
+  - Use `!` or `BREAKING CHANGE:` footer for breaking changes
+  - Keep commits focused and atomic
+- The scope should reflect the portion of the package that was modified, for example if your module is `github.com/user/gotool`:
+  - If modifying the module root or main package, use the package name as scope: `gotool`
+  - If modifying `pkg/utils/helpers.go`, use scope `utils`
+  - If modifying `internal/parser/parser.go`, use scope `parser`
+  - If modifying multiple packages, use the most relevant or common scope
+- Changes to GitHub Actions files should use the type `ci`.
+- Changes to repository configuration files such as `pre-commit-config.yaml`, should use the type `chore`.
+- Changes to the Cursor rules files should use the type `chore` with the scope `cursor`.
+- Changes to `go.mod` or `go.sum` should use the type `chore` with scope `deps`.
+
+## Commit Organization
+
+- **Group changes into small logical commits** - instead of making one large commit with multiple bullet points in the message, break changes into separate commits where each commit represents a single logical change or feature addition/fix
+
+## Examples
+
+- `feat(cli): add new CLI command for file processing`
+- `fix(parser): handle empty input files correctly`
+- `docs(readme): update README with installation instructions`
+- `chore(deps): update go dependencies`
+
+## Best Practices
+
+- Keep commits focused and atomic
+- Write clear, descriptive commit messages
+- Reference issues when applicable
+- Use present tense in commit messages
+
+## Extra CLI commands for git
+
+This section describes extra commands that should be used in preference of the
+default commands.
+
+- INSTEAD OF `git commit -m "[message]"` use `gcom "[message]"` to commit changes.
+- INSTEAD OF `git diff --cached` use `gsta | cat` to view all of the staged changes without pager interference.
+- INSTEAD OF `git diff` use `gdiff | cat` to view unstaged changes.
+- Use `gundo` to revert a commit automatically that was wrong.
+- Use `gunstage` to unstage changes that should not have been added.
+description:
+globs:
+alwaysApply: false
+---

--- a/golang/golang-version-control.mdc
+++ b/golang/golang-version-control.mdc
@@ -6,35 +6,44 @@ alwaysApply: true
 
 # Version Control Guidelines
 
-These rules describe how to use `git` version control and should be used whenever working with version control.
+These rules describe how to use `git` version control and should be used
+whenever working with version control.
 
 ## Pre-commit linting and formatting
 
 - This project uses pre-commit hooks - they will be run on commit.
-- IF there are errors, sometimes they are fixed automatically, and need to be re-added to the staged changes.
+- IF there are errors, sometimes they are fixed automatically, and need to
+  be re-added to the staged changes.
 - IF the errors are not fixed automatically, do not attempt to fix them, STOP.
 
 ## Commit Message Standards
 
-- **Always use Conventional Commits for all commit messages** following the specification at <https://www.conventionalcommits.org/en/v1.0.0/>
+- **Always use Conventional Commits for all commit messages** following the
+  specification at <https://www.conventionalcommits.org/en/v1.0.0/>
 - Use the format: `<type>(scope): <description>` - **scope is required**
 - Use the following conventional commit common types:
   - Common types: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`
   - Use `!` or `BREAKING CHANGE:` footer for breaking changes
   - Keep commits focused and atomic
-- The scope should reflect the portion of the package that was modified, for example if your module is `github.com/user/gotool`:
-  - If modifying the module root or main package, use the package name as scope: `gotool`
+- The scope should reflect the portion of the package that was modified,
+  for example if your module is `github.com/user/gotool`:
+  - If modifying the module root or main package, use the package name as
+    scope: `gotool`
   - If modifying `pkg/utils/helpers.go`, use scope `utils`
   - If modifying `internal/parser/parser.go`, use scope `parser`
   - If modifying multiple packages, use the most relevant or common scope
 - Changes to GitHub Actions files should use the type `ci`.
-- Changes to repository configuration files such as `pre-commit-config.yaml`, should use the type `chore`.
+- Changes to repository configuration files such as `pre-commit-config.yaml`,
+  should use the type `chore`.
 - Changes to the Cursor rules files should use the type `chore` with the scope `cursor`.
 - Changes to `go.mod` or `go.sum` should use the type `chore` with scope `deps`.
 
 ## Commit Organization
 
-- **Group changes into small logical commits** - instead of making one large commit with multiple bullet points in the message, break changes into separate commits where each commit represents a single logical change or feature addition/fix
+- **Group changes into small logical commits** - instead of making one large
+  commit with multiple bullet points in the message, break changes into
+  separate commits where each commit represents a single logical change or
+  feature addition/fix
 
 ## Examples
 
@@ -56,11 +65,8 @@ This section describes extra commands that should be used in preference of the
 default commands.
 
 - INSTEAD OF `git commit -m "[message]"` use `gcom "[message]"` to commit changes.
-- INSTEAD OF `git diff --cached` use `gsta | cat` to view all of the staged changes without pager interference.
+- INSTEAD OF `git diff --cached` use `gsta | cat` to view all of the staged
+  changes without pager interference.
 - INSTEAD OF `git diff` use `gdiff | cat` to view unstaged changes.
 - Use `gundo` to revert a commit automatically that was wrong.
 - Use `gunstage` to unstage changes that should not have been added.
-description:
-globs:
-alwaysApply: false
----

--- a/golang/golang-version-management.mdc
+++ b/golang/golang-version-management.mdc
@@ -40,10 +40,12 @@ go list -m <module>
 - Use `go mod tidy` to manage Go module dependencies
 - Keep `go.mod` and `go.sum` up to date with version constraints
 - Regularly update dependencies to latest compatible versions:
+
   ```bash
   go get -u ./...  # Update all dependencies
   go get -u <module>@latest  # Update specific module
   ```
+
 - Use dependency scanning tools when available
 - Document version requirements clearly in documentation
 
@@ -58,7 +60,8 @@ go list -m <module>
 
 - Use commit hashes for GitHub Actions instead of version tags
 - Include version tags as comments for reference
-- Regularly audit dependencies for security vulnerabilities using `go mod tidy` and security scanners
+- Regularly audit dependencies for security vulnerabilities using
+  `go mod tidy` and security scanners
 - Keep all tooling and dependencies updated
 - Review `go.sum` changes for unexpected modifications
 
@@ -68,7 +71,3 @@ go list -m <module>
 - Use version tags (v1.0.0, v2.0.0, etc.) for releases
 - Consider Go's compatibility promise when versioning
 - Use major version suffixes for breaking changes (v2, v3, etc.)
-description:
-globs:
-alwaysApply: false
----

--- a/golang/golang-version-management.mdc
+++ b/golang/golang-version-management.mdc
@@ -1,0 +1,74 @@
+---
+description: Version checking and dependency management best practices for Go
+globs:
+alwaysApply: false
+---
+
+# Version Management Best Practices
+
+## General Principles
+
+- Always check for the latest versions of dependencies and GitHub Actions
+- Never guess or use potentially outdated versions
+- Always verify versions from official repositories
+- Keep GitHub Actions and their versions up to date
+- Use Go modules for dependency management
+
+## Version Checking Commands
+
+Use the following commands to find latest versions:
+
+```bash
+# For GitHub-hosted projects
+gh release list --repo <owner>/<repo> --limit 1
+
+# For GitHub Actions specifically
+gh api repos/<owner>/<repo>/releases/latest
+
+# For GitHub Actions versions
+gh api repos/<owner>/<repo>/tags
+
+# For Go modules, check available versions
+go list -m -versions <module>
+
+# Check what version is currently used
+go list -m <module>
+```
+
+## Go Module Dependency Management
+
+- Use `go mod tidy` to manage Go module dependencies
+- Keep `go.mod` and `go.sum` up to date with version constraints
+- Regularly update dependencies to latest compatible versions:
+  ```bash
+  go get -u ./...  # Update all dependencies
+  go get -u <module>@latest  # Update specific module
+  ```
+- Use dependency scanning tools when available
+- Document version requirements clearly in documentation
+
+## Go Version Management
+
+- Use Go version managers like `g` or `gvm` for local development
+- Specify minimum Go version in `go.mod` file
+- Keep Go version up to date with latest stable releases
+- Test against multiple Go versions in CI when supporting older versions
+
+## Security Considerations
+
+- Use commit hashes for GitHub Actions instead of version tags
+- Include version tags as comments for reference
+- Regularly audit dependencies for security vulnerabilities using `go mod tidy` and security scanners
+- Keep all tooling and dependencies updated
+- Review `go.sum` changes for unexpected modifications
+
+## Module Versioning
+
+- Follow semantic versioning for your own Go modules
+- Use version tags (v1.0.0, v2.0.0, etc.) for releases
+- Consider Go's compatibility promise when versioning
+- Use major version suffixes for breaking changes (v2, v3, etc.)
+description:
+globs:
+alwaysApply: false
+---

--- a/python/python-development.mdc
+++ b/python/python-development.mdc
@@ -9,8 +9,10 @@ alwaysApply: false
 ## Running Python commands
 
 - All commands are managed with `uv` and should use `uv run`
-    - NEVER try to run commands with `python -m` directly, always use `uv run` or `uv run python -m`
-    - ALWAYS prefer invoking commands directly like `uv run pytest` rather than the module like `uv run python -m pytest`
+  - NEVER try to run commands with `python -m` directly, always use `uv run`
+    or `uv run python -m`
+  - ALWAYS prefer invoking commands directly like `uv run pytest` rather than
+    the module like `uv run python -m pytest`
 
 ## Linting
 
@@ -23,8 +25,10 @@ alwaysApply: false
   - Ruff formatter documentation <https://docs.astral.sh/ruff/formatter/>
   - Files can be auto formatted using `uv run ruff format [OPTIONS] [FILES]...`
 - ALWAYS use type hints for all function parameters and return values
-- ALWAYS create an appropriate docstring for functions, classes, and modules following Google style
-  - ALWAYS describe possible edge cases, errors, and conditionals that materially affect the behavior of the documented code
+- ALWAYS create an appropriate docstring for functions, classes, and modules
+  following Google style
+  - ALWAYS describe possible edge cases, errors, and conditionals that
+    materially affect the behavior of the documented code
 - Follow PEP 8 standards
 - Prefer descriptive variable and function names
 - Keep line length to 88 characters (Black formatter default)
@@ -32,18 +36,22 @@ alwaysApply: false
 ## Project Structure
 
 - This project uses `uv` for dependency management
-- Tests should be placed in the `tests/` directory with matching structure to the project codebase
+- Tests should be placed in the `tests/` directory with matching structure to
+  the project codebase
 - Use `pytest` for all testing
-    - ALWAYS use the format `uv run pytest [options] [file_or_dir] [file_or_dir] [...]` when running tests
-    - NEVER try to run `python -m pytest`
-    - Pytest documentation <https://docs.pytest.org/en/stable/how-to/usage.html>
+  - ALWAYS use the format `uv run pytest [options] [file_or_dir] [file_or_dir] [...]`
+    when running tests
+  - NEVER try to run `python -m pytest`
+  - Pytest documentation <https://docs.pytest.org/en/stable/how-to/usage.html>
 - Follow the existing project structure when adding new modules
 
 ## Dependencies & Imports
 
 - Use uv to manage dependencies via `pyproject.toml`
-    - Use appropriate `--group` arguments to `uv add` when adding dependencies so we don't add main package dependencies unnecessarily
-        - The default groups should be "dev" and "docs", with other specific groups created only by the user
+  - Use appropriate `--group` arguments to `uv add` when adding dependencies
+    so we don't add main package dependencies unnecessarily
+    - The default groups should be "dev" and "docs", with other specific
+      groups created only by the user
 - Group imports: standard library, third-party, local imports
 - Use absolute imports when possible
 - Avoid circular imports

--- a/python/python-general.mdc
+++ b/python/python-general.mdc
@@ -6,7 +6,8 @@ alwaysApply: true
 # Always applied rules
 
 - These rules MUST always be followed.
-- It is NECESSARY and SUFFICIENT for these rules to be followed for a chat to be successful.
+- It is NECESSARY and SUFFICIENT for these rules to be followed for a chat
+  to be successful.
 - NEVER ignore any of these rules.
 - ALWAYS consider these rules highest priority.
 - Failure to follow these rules will result in immediate termination of the chat.

--- a/python/python-github-actions.mdc
+++ b/python/python-github-actions.mdc
@@ -43,6 +43,7 @@ gh api repos/<owner>/<repo>/tags
 - Include version tags as comments for reference
 
 Example format:
+
 ```yaml
 uses: owner/repo@commit_hash # v1.2.3
 ```

--- a/python/python-markdown-documentation.mdc
+++ b/python/python-markdown-documentation.mdc
@@ -6,21 +6,26 @@ alwaysApply: false
 
 # Documentation Guidelines
 
-@Docs https://github.github.com/gfm/
+@Docs <https://github.github.com/gfm/>
 
 ## Markdown Formatting
 
 - Keep all documentation files properly formatted
 - Run markdown linting before committing documentation changes
   - ALWAYS use `pre-commit` for linting and formatting
-  - ALWAYS use `pre-commit run [--all-files | --files [FILES ...]] prettier` to ensure markdown files conform to prettier's standards before running markdown lint
-  - ALWAYS use `pre-commit run [--all-files | --files [FILES ...]] markdownlint-cli2` hook for formatting a specific markdown file or all markdown files in the repository
-  - IF AND ONLY IF `pre-commit` is not available as a command, `uv run pre-commit` should be used as a fallback
--  Use proper markdown formatting:
-  - Add blank lines before and after code blocks
-  - Use proper heading hierarchy
-  - Keep line length reasonable (88 characters)
-  - Use proper list formatting with blank lines between list items
+  - ALWAYS use `pre-commit run [--all-files | --files [FILES ...]] prettier`
+    to ensure markdown files conform to prettier's standards before running
+    markdown lint
+  - ALWAYS use `pre-commit run [--all-files | --files [FILES ...]] markdownlint-cli2`
+    hook for formatting a specific markdown file or all markdown files in the
+    repository
+  - IF AND ONLY IF `pre-commit` is not available as a command, `uv run pre-commit`
+    should be used as a fallback
+- Use proper markdown formatting:
+- Add blank lines before and after code blocks
+- Use proper heading hierarchy
+- Keep line length reasonable (88 characters)
+- Use proper list formatting with blank lines between list items
 
 ## Documentation Standards
 

--- a/python/python-packaging-modernization.mdc
+++ b/python/python-packaging-modernization.mdc
@@ -7,11 +7,13 @@ alwaysApply: false
 
 ## Converting setuptools to pyproject.toml
 
-When encountering legacy `setup.py` or `setup.cfg` files, convert them to modern `pyproject.toml` format following these guidelines:
+When encountering legacy `setup.py` or `setup.cfg` files, convert them to
+modern `pyproject.toml` format following these guidelines:
 
 ### Build System Configuration
 
 - Use `hatchling` as the build backend for compatibility with uv:
+
 ```toml
 [build-system]
 requires = ["hatchling"]
@@ -41,6 +43,7 @@ dependencies = [
 ### Section Ordering
 
 Organize sections in this order:
+
 1. `[project]` - All project metadata
 2. `[project.entry-points.*]` - Entry points configuration
 3. `[dependency-groups]` - Optional dependency groups (if needed)
@@ -50,6 +53,7 @@ Organize sections in this order:
 ### Entry Points Migration
 
 Convert setuptools entry points format:
+
 ```python
 # OLD setup.py
 entry_points={
@@ -59,6 +63,7 @@ entry_points={
 ```
 
 To modern toml format:
+
 ```toml
 [project.scripts]
 cmd = "module:function"
@@ -71,7 +76,8 @@ key = "module"
 
 - Always declare dependencies explicitly in the `dependencies` array
 - Use appropriate version constraints
-- For the pyconfig project, ensure `pyconfig` is listed as a dependency for test packages
+- For the pyconfig project, ensure `pyconfig` is listed as a dependency for
+  test packages
 
 ### Author Information
 

--- a/python/python-testing.mdc
+++ b/python/python-testing.mdc
@@ -8,15 +8,19 @@ alwaysApply: false
 
 ## What to test
 
-- Start with creating exercise tests, testing intended behavior of functions, classes, and modules
-- Try to minimally mock so we ensure that we aren't creating passthrough tests of no value
-- Once we have good exercise tests, then continue to create more tests for common edge cases
+- Start with creating exercise tests, testing intended behavior of functions,
+  classes, and modules
+- Try to minimally mock so we ensure that we aren't creating passthrough
+  tests of no value
+- Once we have good exercise tests, then continue to create more tests for
+  common edge cases
 
 ## Writing and refactoring tests
 
 - ALWAYS check linting after modifying a file before going on to the next file
 - ALWAYS run tests for the specific file after modifying to ensure tests pass
-- IF you are in the middle of modifying multiple files or refactoring, it may be okay that tests do not pass
+- IF you are in the middle of modifying multiple files or refactoring, it
+  may be okay that tests do not pass
 
 ## Test Structure & Organization
 
@@ -35,7 +39,9 @@ alwaysApply: false
 - Mock external dependencies appropriately
 - Test both success and failure cases
 - Include edge case testing
-- NEVER compare values to `True`, `False`, `None`, with equality comparisons `==`, use `is` or a direct truth check as appropriate based on the test content
+- NEVER compare values to `True`, `False`, `None`, with equality comparisons
+  `==`, use `is` or a direct truth check as appropriate based on the test
+  content
 
 ## Fixtures & Setup
 

--- a/python/python-version-control.mdc
+++ b/python/python-version-control.mdc
@@ -6,34 +6,43 @@ alwaysApply: true
 
 # Version Control Guidelines
 
-These rules describe how to use `git` version control and should be used whenever working with version control.
+These rules describe how to use `git` version control and should be used
+whenever working with version control.
 
 ## Pre-commit linting and formatting
 
 - This project uses pre-commit hooks - they will be run on commit.
-- IF there are errors, sometimes they are fixed automatically, and need to be re-added to the staged changes.
+- IF there are errors, sometimes they are fixed automatically, and need to
+  be re-added to the staged changes.
 - IF the errors are not fixed automatically, do not attempt to fix them, STOP.
 
 ## Commit Message Standards
 
-- **Always use Conventional Commits for all commit messages** following the specification at <https://www.conventionalcommits.org/en/v1.0.0/>
+- **Always use Conventional Commits for all commit messages** following the
+  specification at <https://www.conventionalcommits.org/en/v1.0.0/>
 - Use the format: `<type>(scope): <description>` - **scope is required**
 - Use the following conventional commit common types:
   - Common types: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`
   - Use `!` or `BREAKING CHANGE:` footer for breaking changes
   - Keep commits focused and atomic
-- The scope should reflect the portion of the package that was modified, for example if your package is `pytool`:
-  - If modifying the package root, `pytool/__init__.py` then the scope is `pytool`, or the package name.
+- The scope should reflect the portion of the package that was modified,
+  for example if your package is `pytool`:
+  - If modifying the package root, `pytool/__init__.py` then the scope is
+    `pytool`, or the package name.
   - If modifying `pytool/lang.py`, use scope `lang`
   - If modifying `pytool/utils/helpers.py`, use scope `utils`
   - If modifying multiple modules, use the most relevant or common scope
 - Changes to GitHub Actions files should use the type `ci`.
-- Changes to repository configuration files such as `pre-commit-config.yaml`, should use the type `chore`.
+- Changes to repository configuration files such as `pre-commit-config.yaml`,
+  should use the type `chore`.
 - Changes to the Cursor rules files should use the type `chore` with the scope `cursor`.
 
 ## Commit Organization
 
-- **Group changes into small logical commits** - instead of making one large commit with multiple bullet points in the message, break changes into separate commits where each commit represents a single logical change or feature addition/fix
+- **Group changes into small logical commits** - instead of making one large
+  commit with multiple bullet points in the message, break changes into
+  separate commits where each commit represents a single logical change or
+  feature addition/fix
 
 ## Examples
 
@@ -54,7 +63,8 @@ This section describes extra commands that should be used in preference of the
 default commands.
 
 - INSTEAD OF `git commit -m "[message]"` use `gcom "[message]"` to commit changes.
-- INSTEAD OF `git diff --cached` use `gsta | cat` to view all of the staged changes without pager interference.
+- INSTEAD OF `git diff --cached` use `gsta | cat` to view all of the staged
+  changes without pager interference.
 - INSTEAD OF `git diff` use `gdiff | cat` to view unstaged changes.
 - Use `gundo` to revert a commit automatically that was wrong.
 - Use `gunstage` to unstage changes that should not have been added.


### PR DESCRIPTION
This PR adds a complete set of Golang cursor rules ported from the existing Python rules.

## Changes
- Created  directory with 9 new rule files
- Adapted Python-specific tooling to Go equivalents (uv → go mod, pytest → go test, etc.)
- Added Ginkgo/Gomega testing guidelines that run through standard go test CLI
- Included Go-specific best practices for modules, error handling, and concurrency
- Maintained same .mdc structure and YAML frontmatter as Python rules

## Key Adaptations
- **Testing**: Configured for Ginkgo/Gomega BDD testing framework
- **Linting**: Uses golangci-lint instead of ruff
- **Modules**: Go module management instead of Python packaging
- **Toolchain**: Standard Go tools (go build, go test, go mod)
- **Documentation**: Go doc conventions and package examples

All rules follow Go idioms and best practices while maintaining consistency with the existing Python rule structure.